### PR TITLE
Remove local variable declaration, as the variable is already defined globally

### DIFF
--- a/full/full_func.php
+++ b/full/full_func.php
@@ -7,7 +7,7 @@ function determine_type($f)
 	return d_is_dir($f) ? tDIR : tFILE;
 }
 
-function get_info($f, $_REQUEST = array())
+function get_info($f)
 {
 	global $descr;
 	


### PR DESCRIPTION
Without this fix, Dolphin Manager doesn't work on my PHP 5.6 system.
